### PR TITLE
Improve listener logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.log
 *.crt
 *.key
+*.key.*
 *.zip
+uploader.sh
 
 .idea/
 .history/

--- a/src/lib/dataElements/gtmDlPropertyKey.js
+++ b/src/lib/dataElements/gtmDlPropertyKey.js
@@ -44,7 +44,7 @@ module.exports = function (settings, event) {
       'a property was read from the current datalayer ' +
         JSON.stringify(property)
     );
-    return window.helper.get(property);
+    return window.extensionGoogleDataLayer.dataLayerHelper.get(property);
   }
 
   /* try first to get the property from the current event

--- a/src/lib/events/gtmDlPushEvent.js
+++ b/src/lib/events/gtmDlPushEvent.js
@@ -12,19 +12,21 @@ governing permissions and limitations under the License.
 'use strict';
 
 const constants = require('../helpers/constants');
+const triggers = [];
 
-module.exports = function (settings, trigger) {
-  if (!settings) return;
+const handler = function (argEvent) {
+  triggers.forEach(function (triggerData) {
+    const settings = triggerData.setting;
+    const trigger = triggerData.trigger;
 
-  const { method, valueIsRegex, eventKey } = settings;
-
-  function handler(argEvent) {
+    const { method, valueIsRegex, eventKey } = settings;
     const eventModel =
       argEvent && argEvent.detail && argEvent.detail.eventModel;
 
     const result = {
       event: argEvent.detail
     };
+
     if (method !== constants.SPECIFICEVENT) {
       trigger(result);
       return;
@@ -40,13 +42,19 @@ module.exports = function (settings, trigger) {
     } else if (eventKey === eventName) {
       trigger(result);
     }
-  }
-  if (method === constants.ALLDATA) {
-    document.body.addEventListener(constants.GDATA, handler);
-  } else if (
-    method === constants.ALLEVENTS ||
-    (method === constants.SPECIFICEVENT && eventKey !== '')
-  ) {
-    document.body.addEventListener(constants.GEVENT, handler);
-  }
+  });
+};
+
+let initializeListener = function () {
+  document.body.addEventListener(constants.DATALAYERCHANGE, handler);
+  initializeListener = function () {};
+};
+
+module.exports = function (settings, trigger) {
+  triggers.push({
+    settings: settings,
+    trigger: trigger
+  });
+
+  initializeListener();
 };

--- a/src/lib/events/gtmDlPushEvent.js
+++ b/src/lib/events/gtmDlPushEvent.js
@@ -16,7 +16,7 @@ const triggers = [];
 
 const handler = function (argEvent) {
   triggers.forEach(function (triggerData) {
-    const settings = triggerData.setting;
+    const settings = triggerData.settings;
     const trigger = triggerData.trigger;
 
     const { method, valueIsRegex, eventKey } = settings;
@@ -27,20 +27,34 @@ const handler = function (argEvent) {
       event: argEvent.detail
     };
 
-    if (method !== constants.SPECIFICEVENT) {
+    const eventName = eventModel && eventModel.event;
+
+    if (method === constants.METHOD_ALLCHANGES) {
       trigger(result);
       return;
     }
 
-    const eventName = eventModel && eventModel.event;
-
-    if (valueIsRegex) {
-      const re = new RegExp(eventKey);
-      if (String(eventName).match(re)) {
+    if (!eventName) {
+      if (method === constants.METHOD_ALLDATA) {
         trigger(result);
       }
-    } else if (eventKey === eventName) {
+      return;
+    }
+
+    if (method === constants.METHOD_ALLEVENTS) {
       trigger(result);
+      return;
+    }
+
+    if (method === constants.METHOD_SPECIFICEVENT) {
+      if (valueIsRegex) {
+        const re = new RegExp(eventKey);
+        if (String(eventName).match(re)) {
+          trigger(result);
+        }
+      } else if (eventKey === eventName) {
+        trigger(result);
+      }
     }
   });
 };

--- a/src/lib/helpers/constants.js
+++ b/src/lib/helpers/constants.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 'use strict';
 
 const constants = {
+  DATALAYERCHANGE: 'dataLayerChange',
   GEVENT: 'gtmDlEvent',
   GDATA: 'gtmDlData',
   SPECIFICEVENT: 'specificEvent',

--- a/src/lib/helpers/constants.js
+++ b/src/lib/helpers/constants.js
@@ -16,6 +16,7 @@ const constants = {
   GDATA: 'gtmDlData',
   SPECIFICEVENT: 'specificEvent',
   ALLEVENTS: 'allEvents',
-  ALLDATA: 'allData'
+  ALLDATA: 'allData',
+  DEFAULTDATALAYER: 'dataLayer'
 };
 module.exports = Object.freeze(constants);

--- a/src/lib/helpers/constants.js
+++ b/src/lib/helpers/constants.js
@@ -13,11 +13,10 @@ governing permissions and limitations under the License.
 
 const constants = {
   DATALAYERCHANGE: 'dataLayerChange',
-  GEVENT: 'gtmDlEvent',
-  GDATA: 'gtmDlData',
-  SPECIFICEVENT: 'specificEvent',
-  ALLEVENTS: 'allEvents',
-  ALLDATA: 'allData',
+  METHOD_SPECIFICEVENT: 'specificEvent',
+  METHOD_ALLEVENTS: 'allEvents',
+  METHOD_ALLDATA: 'allData',
+  METHOD_ALLCHANGES: 'allChanges',
   DEFAULTDATALAYER: 'dataLayer'
 };
 module.exports = Object.freeze(constants);

--- a/src/lib/helpers/getDataLayer.js
+++ b/src/lib/helpers/getDataLayer.js
@@ -11,6 +11,12 @@ governing permissions and limitations under the License.
 
 'use strict';
 
+/*
+set/get datalayer from window object as this is Google standard
+support for multiple data layers in backlog:
+https://github.com/adobe/reactor-extension-googledatalayer/issues/1
+*/
+
 module.exports = () => {
   const name = turbine.getExtensionSettings().dataLayer;
   window[name] = window[name] || [];

--- a/src/lib/helpers/getHelper.js
+++ b/src/lib/helpers/getHelper.js
@@ -7,7 +7,7 @@ jQuery v1.9.1 (c) 2005, 2012
 jQuery Foundation, Inc. jquery.org/license.
 */
 
-/* code has been altered to use window.adobe.DataLayerHelper instead of window.DataLayerHelper line 22,23 */
+/* code has been altered to use window.extensionGoogleDataLayer.DataLayerHelper instead of window.DataLayerHelper line 22,23 */
 /* code state #9e00d56 17 Aug 2020 https://github.com/google/data-layer-helper/blob/master/dist/data-layer-helper.js */
 
 module.exports = () => {
@@ -169,8 +169,8 @@ module.exports = () => {
     r.prototype.flatten = r.prototype.flatten;
     r.prototype.get = r.prototype.get;
     r.prototype.process = r.prototype.process;
-    window.adobe = window.adobe || {};
-    window.adobe.DataLayerHelper = r;
+    window.extensionGoogleDataLayer = window.extensionGoogleDataLayer || {};
+    window.extensionGoogleDataLayer.DataLayerHelper = r;
     function u(a) {
       return {
         set: function (b, c) {

--- a/src/lib/helpers/instantiateGtmDlHelper.js
+++ b/src/lib/helpers/instantiateGtmDlHelper.js
@@ -19,24 +19,15 @@ require('./polyfill')();
 window.extensionGoogleDataLayer.dataLayerHelper =
   new window.extensionGoogleDataLayer.DataLayerHelper(getDataLayer(), {
     listener: function (argDataLayerModel, argEventModel) {
-      if (argEventModel.event) {
-        document.body.dispatchEvent(
-          new CustomEvent(constants.DATALAYERCHANGE, {
-            bubbles: false,
-            detail: {
-              dataLayerModel: argDataLayerModel,
-              eventModel: argEventModel
-            }
-          })
-        );
-      } else {
-        document.body.dispatchEvent(
-          new CustomEvent(constants.DATALAYERCHANGE, {
-            bubbles: false,
-            detail: { dataLayerModel: argDataLayerModel }
-          })
-        );
-      }
+      document.body.dispatchEvent(
+        new CustomEvent(constants.DATALAYERCHANGE, {
+          bubbles: false,
+          detail: {
+            dataLayerModel: argDataLayerModel,
+            eventModel: argEventModel
+          }
+        })
+      );
     },
     listenToPast: true
   });

--- a/src/lib/helpers/instantiateGtmDlHelper.js
+++ b/src/lib/helpers/instantiateGtmDlHelper.js
@@ -20,7 +20,7 @@ new window.adobe.DataLayerHelper(getDataLayer(), {
   listener: function (argDataLayerModel, argEventModel) {
     if (argEventModel.event) {
       document.body.dispatchEvent(
-        new CustomEvent(constants.GEVENT, {
+        new CustomEvent(constants.DATALAYERCHANGE, {
           bubbles: false,
           detail: {
             dataLayerModel: argDataLayerModel,
@@ -30,7 +30,7 @@ new window.adobe.DataLayerHelper(getDataLayer(), {
       );
     } else {
       document.body.dispatchEvent(
-        new CustomEvent(constants.GDATA, {
+        new CustomEvent(constants.DATALAYERCHANGE, {
           bubbles: false,
           detail: { dataLayerModel: argDataLayerModel }
         })

--- a/src/lib/helpers/instantiateGtmDlHelper.js
+++ b/src/lib/helpers/instantiateGtmDlHelper.js
@@ -16,26 +16,27 @@ const getDataLayer = require('./getDataLayer');
 require('./getHelper')();
 require('./polyfill')();
 
-new window.adobe.DataLayerHelper(getDataLayer(), {
-  listener: function (argDataLayerModel, argEventModel) {
-    if (argEventModel.event) {
-      document.body.dispatchEvent(
-        new CustomEvent(constants.GEVENT, {
-          bubbles: false,
-          detail: {
-            dataLayerModel: argDataLayerModel,
-            eventModel: argEventModel
-          }
-        })
-      );
-    } else {
-      document.body.dispatchEvent(
-        new CustomEvent(constants.GDATA, {
-          bubbles: false,
-          detail: { dataLayerModel: argDataLayerModel }
-        })
-      );
-    }
-  },
-  listenToPast: true
-});
+window.extensionGoogleDataLayer.dataLayerHelper =
+  new window.extensionGoogleDataLayer.DataLayerHelper(getDataLayer(), {
+    listener: function (argDataLayerModel, argEventModel) {
+      if (argEventModel.event) {
+        document.body.dispatchEvent(
+          new CustomEvent(constants.GEVENT, {
+            bubbles: false,
+            detail: {
+              dataLayerModel: argDataLayerModel,
+              eventModel: argEventModel
+            }
+          })
+        );
+      } else {
+        document.body.dispatchEvent(
+          new CustomEvent(constants.GDATA, {
+            bubbles: false,
+            detail: { dataLayerModel: argDataLayerModel }
+          })
+        );
+      }
+    },
+    listenToPast: true
+  });

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -13,6 +13,7 @@ import React from 'react';
 
 import ExtensionView from '../components/extensionView';
 import WrappedTextField from '../components/wrappedTextField';
+import constants from '../../lib/helpers/constants';
 
 export default () => {
   return (
@@ -22,7 +23,7 @@ export default () => {
         const { dataLayer } = settings || {};
 
         return {
-          dataLayer: dataLayer || 'dataLayer'
+          dataLayer: dataLayer || constants.DEFAULTDATALAYER
         };
       }}
       getSettings={({ values: { dataLayer } }) => ({
@@ -41,10 +42,10 @@ export default () => {
         <WrappedTextField
           minWidth="size-6000"
           name="dataLayer"
-          label="Google Data Layer object name"
+          label="Google Data Layer name"
           isRequired
           necessityIndicator="label"
-          description="Your Google Data Layer name, for example dataLayer."
+          description="e.g. <em>dataLayer</em>. Do not include <em>window</em> - this is implicit"
         />
       )}
     />

--- a/src/view/configuration/configuration.jsx
+++ b/src/view/configuration/configuration.jsx
@@ -45,7 +45,7 @@ export default () => {
           label="Google Data Layer name"
           isRequired
           necessityIndicator="label"
-          description="e.g. <em>dataLayer</em>. Do not include <em>window</em> - this is implicit"
+          description="e.g. dataLayer. Do not include 'window' - this is implicit"
         />
       )}
     />

--- a/src/view/events/gtmDlPushEvent.jsx
+++ b/src/view/events/gtmDlPushEvent.jsx
@@ -26,7 +26,7 @@ export default () => {
         const { method, eventKey, valueIsRegex } = settings || {};
 
         return {
-          method: method || constants.SPECIFICEVENT,
+          method: method || constants.METHOD_ALLCHANGES,
           eventKey,
           valueIsRegex
         };
@@ -36,7 +36,7 @@ export default () => {
           method
         };
 
-        if (method === constants.SPECIFICEVENT) {
+        if (method === constants.METHOD_SPECIFICEVENT) {
           if (valueIsRegex) {
             settings.valueIsRegex = true;
           }
@@ -49,7 +49,7 @@ export default () => {
       validate={({ eventKey, method }) => {
         const errors = {};
 
-        if (!eventKey && method === constants.SPECIFICEVENT) {
+        if (!eventKey && method === constants.METHOD_SPECIFICEVENT) {
           errors.eventKey = 'Please provide an event key';
         }
 
@@ -71,11 +71,16 @@ export default () => {
                   value={value}
                   onChange={onChange}
                 >
-                  <Radio value={constants.ALLDATA}>
-                    Changes excluding events
+                  <Radio value={constants.METHOD_ALLCHANGES}>
+                    All Pushes to the Data Layer
                   </Radio>
-                  <Radio value={constants.ALLEVENTS}>All Events</Radio>
-                  <Radio value={constants.SPECIFICEVENT}>Specific Event</Radio>
+                  <Radio value={constants.METHOD_ALLDATA}>
+                    Pushes excluding events
+                  </Radio>
+                  <Radio value={constants.METHOD_ALLEVENTS}>All Events</Radio>
+                  <Radio value={constants.METHOD_SPECIFICEVENT}>
+                    Specific Event
+                  </Radio>
                 </RadioGroup>
               )}
             />
@@ -95,10 +100,16 @@ export default () => {
               </Flex>
             )}
             <Heading level={2}>Examples</Heading>
-            <Heading level={3}>Listen to all data changes</Heading>
+            <Heading level={3}>Listen to all pushes</Heading>
             <p>
-              Listening to all data changes will trigger the rule when data are
-              being pushed to the Data Layer (excluding during events).
+              Listening to all pushes will trigger the rule when data or events
+              are pushed to the Data Layer.
+            </p>
+            <Heading level={3}>Listen to all data pushes</Heading>
+            <p>
+              Listening to all data pushes will trigger the rule when data are
+              being pushed to the Data Layer, but not during events, i.e. not
+              when the event keyword is used.
             </p>
             <p>This push will trigger the rule: </p>
             <div className="code">
@@ -119,7 +130,7 @@ export default () => {
             </div>
             <Heading level={3}>Listen to all events</Heading>
             <p>
-              Listening to all event will trigger the rule when an event are
+              Listening to all event will trigger the rule when any event is
               being pushed to the Data Layer.
             </p>
             <p>This push will trigger the rule: </p>{' '}


### PR DESCRIPTION
## Description

Changed the code so that a listener is added on document.body only once. And only if there is a rule with the `Google DL Push Event`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
