### PR TITLE
bugfix 27 - add code to handle gtag type event structure

### DIFF
--- a/src/lib/events/gtmDlPushEvent.js
+++ b/src/lib/events/gtmDlPushEvent.js
@@ -28,7 +28,14 @@ const handler = function (argEvent) {
       event: argEvent.detail
     };
 
-    const eventName = eventModel && eventModel.event;
+    let eventName = eventModel && eventModel.event;
+    /* handle gtag() type event (event keyword and name are pushed as array items) */
+    if (!eventName) {
+      eventName =
+        eventModel[0] === constants.KEYWORD_EVENT && eventModel[1]
+          ? eventModel[1]
+          : undefined;
+    }
 
     if (method === constants.METHOD_ALLCHANGES) {
       trigger(result);

--- a/src/lib/helpers/constants.js
+++ b/src/lib/helpers/constants.js
@@ -17,6 +17,7 @@ const constants = {
   METHOD_ALLEVENTS: 'allEvents',
   METHOD_ALLDATA: 'allData',
   METHOD_ALLCHANGES: 'allChanges',
-  DEFAULTDATALAYER: 'dataLayer'
+  DEFAULTDATALAYER: 'dataLayer',
+  KEYWORD_EVENT: 'event'
 };
 module.exports = Object.freeze(constants);

--- a/src/view/events/gtmDlPushEvent.jsx
+++ b/src/view/events/gtmDlPushEvent.jsx
@@ -105,6 +105,25 @@ export default () => {
               risk introducing infinite loops, particularly with the option to
               listen for all data pushes.
             </p>
+            <Heading level={2}>GTag Type Data Structure</Heading>
+            <p>
+              Use of the gtag() function will result in an entry in the
+              datalayer that differs from the push() examples used in the
+              information in this page. Instead of a key &quot;event&quot; with
+              a value <em>eventName</em>, a gtag event results in a simple array
+              in the datalayer as shown below:
+            </p>
+            <div className="code">
+              0:&quot;event&quot;
+              <br />
+              1:&quot;page_view&quot;
+              <br />
+              2:{}
+            </div>
+            <p>
+              The GTag event format is supported in the extension since version
+              1.2.1.
+            </p>
             <Heading level={2}>Accessing the Event Object</Heading>
             <p>
               The data element included in the Google Data Layer extension gives


### PR DESCRIPTION
see issue #27

gtag code can be seen here: https://ga-dev-tools.google/ga4/enhanced-ecommerce/products/comverges-t-shirt/

eg

`gtag("event",  "add_to_cart",  {
  "currency": "USD",
  "value": 20,
  "items": [{
    "item_id": "2",
    "item_name": "Comverges T-Shirt",
    "price": "20",
    "item_brand": "Comverges",
    "item_category": "T-shirt",
    "index": 0,
    "size": "M"
  }]
});`

gives (in datalayer) an array with [0] = 'event', [1] = 'add_to_cart', [2] = everything else.  This was not handled as an event in the extension



